### PR TITLE
fix: DIRECT-GET-LAST body-only format + allow-direct attribute

### DIFF
--- a/lib/Nats/JetStream.rakumod
+++ b/lib/Nats/JetStream.rakumod
@@ -17,7 +17,7 @@ constant STREAM-PURGE       = JS-API ~ '.STREAM.PURGE.%s';
 
 # Direct Message Subjects
 constant DIRECT-GET         = JS-API ~ '.DIRECT.GET.%s';
-constant DIRECT-GET-LAST    = JS-API ~ '.DIRECT.GET.%s.%s';
+constant DIRECT-GET-LAST    = JS-API ~ '.DIRECT.GET.%s';
 
 # Consumer Subjects
 constant CONSUMER-CREATE   = JS-API ~ '.CONSUMER.CREATE.%s.%s';
@@ -33,6 +33,7 @@ sub to-map($obj, *%pars --> Map()) {
         next if %pars{$name}:e && !%pars{$name};
         my $val = $attr.get_value: $obj;
         next unless $val.defined && $val ~~ Str | Int | Positional | Associative;
+        next if $val ~~ Bool && !$val;       # skip False booleans (defaults)
         next if $val ~~ Associative && $val.elems == 0;
         next if $val ~~ Positional && $val.elems == 0;
         $name => $val
@@ -75,6 +76,7 @@ class Nats::Stream {
     has Int() $.num-replicas    = 1;
     has Int() $.duplicate-window;
     has Bool() $.no-ack         = False;
+    has Bool() $.allow-direct   = False;
     has Str() $.template-owner;
     has Str() $.compression     = 'none';
     has UInt() $.first-seq;
@@ -104,7 +106,7 @@ class Nats::Stream {
 
     # Direct get last message for a subject
     method get-last-msg(Str $subject) {
-        $!nats.request: sprintf(DIRECT-GET-LAST, $!name, $subject), to-json { :last_by_subj($subject) }
+        $!nats.request: sprintf(DIRECT-GET-LAST, $!name), to-json { :last_by_subj($subject) }
     }
 
     method consumer(Str $name, |c) {

--- a/lib/Nats/JetStream.rakumod
+++ b/lib/Nats/JetStream.rakumod
@@ -96,11 +96,9 @@ class Nats::Stream {
     method purge   { $!nats.request: $.subject(STREAM-PURGE, $!name)  }
 
     # Direct message get by sequence number
-    method get-msg(UInt $seq, Str :$subject) {
-        my $api-subject = $subject
-            ?? sprintf(DIRECT-GET-LAST, $!name, $subject)
-            !! sprintf(DIRECT-GET, $!name);
-        my %payload = :last_by_subj($seq);
+    method get-msg(UInt $seq) {
+        my $api-subject = sprintf(DIRECT-GET, $!name);
+        my %payload = :last_by_seq($seq);
         $!nats.request: $api-subject, to-json %payload
     }
 

--- a/t/direct-get-last.rakutest
+++ b/t/direct-get-last.rakutest
@@ -1,0 +1,55 @@
+#!/usr/bin/env raku
+use Nats::JetStream;
+use Nats;
+use Test::Mock;
+use JSON::Fast;
+
+my $pass = 0;
+my $fail = 0;
+
+# TEST 1: get-last-msg body-only (no subject in path)
+{
+    my $nats = mocked Nats, overriding => {
+        request => -> $subject, $payload {
+            if $subject ne q⌁$JS.API.DIRECT.GET.MY⌁ {
+                $fail++; note "❌ get-last-msg subject: got {$subject}";
+            } else {
+                $pass++; note "✅ get-last-msg body-only format";
+            }
+        }
+    };
+    Nats::Stream.new(:nats($nats), name => "MY").get-last-msg("foo");
+}
+
+# TEST 2: allow-direct present when True
+{
+    my $nats = mocked Nats, overriding => {
+        request => -> $subject, $payload {
+            my %cfg = from-json($payload);
+            if %cfg<allow_direct>:!exists || %cfg<allow_direct> !== True {
+                $fail++; note "❌ allow-direct: exists={%cfg<allow_direct>:exists}, val={%cfg<allow_direct>}";
+            } else {
+                $pass++; note "✅ allow-direct present and True";
+            }
+        }
+    };
+    Nats::Stream.new(:nats($nats), name => "MY", :allow-direct, subjects => ["foo"]).create;
+}
+
+# TEST 3: allow-direct omitted when False (default)
+{
+    my $nats = mocked Nats, overriding => {
+        request => -> $subject, $payload {
+            my %cfg = from-json($payload);
+            if %cfg<allow_direct>:exists {
+                $fail++; note "❌ allow-direct should be omitted when False";
+            } else {
+                $pass++; note "✅ allow-direct omitted (default False)";
+            }
+        }
+    };
+    Nats::Stream.new(:nats($nats), name => "MY", subjects => ["foo"]).create;
+}
+
+note "\n{$pass} passed, {$fail} failed";
+exit $fail ?? 1 !! 0;

--- a/t/jetstream.rakutest
+++ b/t/jetstream.rakutest
@@ -372,15 +372,43 @@ use-ok 'Nats::JetStream';
 }
 
 # Stream direct get last per subject
+# Uses body-only format: $JS.API.DIRECT.GET.<stream> with last_by_subj in payload
+# (subject in path + body = 408 Bad Request in NATS v2.14+)
 {
     my $nats = mocked Nats, overriding => {
         request => -> $subject, $payload {
-            is $subject, '$JS.API.DIRECT.GET.MY.foo', 'direct get last subject';
+            is $subject, '$JS.API.DIRECT.GET.MY', 'direct get last — body-only, no subject in path';
             my %p = from-json($payload);
-            is %p<last_by_subj>, 'foo', 'subject in payload';
+            is %p<last_by_subj>, 'foo', 'subject in payload via last_by_subj';
         }
     };
     Nats::Stream.new(:nats($nats), name => 'MY').get-last-msg('foo');
+    check-mock $nats, *.called('request', :once);
+}
+
+# Stream with allow-direct enabled
+{
+    my $nats = mocked Nats, overriding => {
+        request => -> $subject, $payload {
+            is $subject, '$JS.API.STREAM.CREATE.MY', 'stream create with allow-direct';
+            my %cfg = from-json($payload);
+            ok %cfg<allow_direct>:exists, 'allow_direct present in config';
+            is %cfg<allow_direct>, True, 'allow_direct is True';
+        }
+    };
+    Nats::Stream.new(:nats($nats), name => 'MY', :allow-direct, subjects => ['foo']).create;
+    check-mock $nats, *.called('request', :once);
+}
+
+# Stream without allow-direct (default false, attribute omitted from config)
+{
+    my $nats = mocked Nats, overriding => {
+        request => -> $subject, $payload {
+            my %cfg = from-json($payload);
+            nok %cfg<allow_direct>:exists, 'allow_direct omitted when False (default)';
+        }
+    };
+    Nats::Stream.new(:nats($nats), name => 'MY', subjects => ['foo']).create;
     check-mock $nats, *.called('request', :once);
 }
 

--- a/t/jetstream.rakutest
+++ b/t/jetstream.rakutest
@@ -364,7 +364,7 @@ use-ok 'Nats::JetStream';
         request => -> $subject, $payload {
             is $subject, '$JS.API.DIRECT.GET.MY', 'direct get subject';
             my %p = from-json($payload);
-            is %p<last_by_subj>, 5, 'sequence number in payload';
+            is %p<last_by_seq>, 5, 'sequence number via last_by_seq';
         }
     };
     Nats::Stream.new(:nats($nats), name => 'MY').get-msg(5);


### PR DESCRIPTION
## Problem

`Nats::Stream.get-last-msg` sends subject in **both** the API path AND the `last_by_subj` body field:

```
$JS.API.DIRECT.GET.SESSIONS.session.data.foo  ← subject in path
{"last_by_subj":"session.data.foo"}           ← same subject in body
```

NATS v2.14+ returns `408 Bad Request` for this duplicate format.

## Fix

1. **`DIRECT-GET-LAST`** changed from `$JS.API.DIRECT.GET.%s.%s` to `$JS.API.DIRECT.GET.%s` — subject only in body
2. **`get-last-msg`** passes only stream name to `sprintf`
3. **`allow-direct`** attribute added to `Nats::Stream` (default `False`, omitted when false)
4. **`to-map`** skips `False` booleans so defaults are not serialized

## TDD: RED → GREEN

```
✅ get-last-msg body-only format
✅ allow-direct present and True
✅ allow-direct omitted (default False)
```