### PR TITLE
ci: add NATS service for integration tests + fix style-violations plan

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,8 +3,15 @@ on: [ push, pull_request ]
 jobs:
   test:
     runs-on: ubuntu-latest
+    services:
+      nats:
+        image: nats:latest
+        ports:
+          - 4222:4222
     steps:
       - name: Test + coverage
+        uses: JJ/raku-test-action@v2
         with:
           coverage: true
-        uses: JJ/raku-test-action@v2
+        env:
+          NATS_URL: nats://localhost:4222


### PR DESCRIPTION
## What

1. **Add NATS service container** to CI workflow — integration tests need a live NATS server. Currently the CI fails because tests try to connect to `localhost:4222` and there's nothing there.

2. **Fix `t/style-violations.rakutest`** — `plan 9` → `plan 8`. There are only 8 assertions (7 test blocks, but block 5 has `nok` + `lives-ok` = 2).

## Why the CI was failing

`zef test` runs tests alphabetically. `direct-get-last.rakutest` (mocked, no NATS needed) passes first (3/3), but then `integration.rakutest` tries to connect to `localhost:4222` and fails because there's no NATS server in the CI environment.

## Testing

- Local: `zef test .` passes with NATS running ✅
- CI: this PR adds `services: nats` so integration tests can connect